### PR TITLE
end_game_handler

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -84,6 +84,11 @@
           game_id: joinGameInput.value,
         });
 
+        socket.emit("end_game", {
+          user_id: playerId,
+          game_id: joinGameInput.value,
+        });
+
         // reset view
         joinGameInput.style.display = "none";
         okButton.style.display = "none";

--- a/server/src/socket/end_game_handler.socket.js
+++ b/server/src/socket/end_game_handler.socket.js
@@ -1,0 +1,21 @@
+// Custom Modules
+const formatMessage = require("./libs/formatMessage");
+
+const end_game_handler = (socket) => ({ user_id, game_id=001}) => {
+
+    // random chess room
+    user_id = "Bla BLaa",
+    
+    // broadcast message to all users in the chessroom  game_id
+    socket.broadcast.to(game_id).emit("message", formatMessage(user_id, `Game has ended in room ${game_id}`));
+
+    // Close socket connection
+    //socket.close(game_id)
+
+     // Welcome current user to the room
+     socket.emit("message", formatMessage(user_id, `Game Over in chess room ${game_id}`));
+
+
+};
+
+module.exports = end_game_handler;

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -1,6 +1,7 @@
 // Custom Modules
 const join_room_handler = require("./join_room_handler.socket.js");
 const leave_room_handler = require("./leave_room_handler.socket.js");
+const end_game_handler = require("./end_game_handler.socket.js");
 const piece_moved_handler = require("./piece_moved_handler.socket.js");
 
 const socket = (socket) => {
@@ -10,6 +11,8 @@ const socket = (socket) => {
   socket.on("join_room", join_room_handler(socket));
 
   socket.on("leave_room", leave_room_handler(socket));
+
+  socket.on("end_game", end_game_handler(socket));
 
   socket.on("piece_moved", piece_moved_handler(socket));
 };


### PR DESCRIPTION
**What does this PR do?**
It handles the socket broadcast logic for when the game ended and the socket needs to be closed. This comes in handy when there's a checkmate or a player concedes.

**What is the relevant GitHub issue?**
Issue #235 

Test link
https://chess.zuri.chat/test
At the moment this populates itself automatically in the test link but would be called when needed in the plugin application.